### PR TITLE
Update to radio change

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2403,7 +2403,8 @@ class radioOptionsInput_RadioOptionsInput extends external_commonjs_react_common
       className: this.props.classes.radioListItem
     }, /*#__PURE__*/external_commonjs_react_commonjs2_react_amd_React_root_React_default.a.createElement("label", {
       className: this.props.classes.radioLabel,
-      id: this.props.labelId
+      id: this.props.labelId,
+      onClick: this.handleChange.bind(this, opt.value)
     }, /*#__PURE__*/external_commonjs_react_commonjs2_react_amd_React_root_React_default.a.createElement("input", {
       type: "radio",
       name: this.props.name,
@@ -2411,6 +2412,7 @@ class radioOptionsInput_RadioOptionsInput extends external_commonjs_react_common
       checked: this.state.value == opt.value,
       className: this.props.classes.radio,
       required: this.props.required ? 'required' : undefined,
+      value: opt.value,
       onChange: this.handleChange.bind(this, opt.value),
       onFocus: this.props.onFocus.bind(this),
       onBlur: this.props.onBlur.bind(null, this.state.value)

--- a/src/inputTypes/radioOptionsInput.js
+++ b/src/inputTypes/radioOptionsInput.js
@@ -23,7 +23,8 @@ class RadioOptionsInput extends React.Component {
           <li key={opt.value}
               className={this.props.classes.radioListItem}>
             <label className={this.props.classes.radioLabel}
-                   id={this.props.labelId}>
+                   id={this.props.labelId}
+                   onClick={this.handleChange.bind(this, opt.value)}>
               <input type="radio"
                      name={this.props.name}
                      aria-labelledby={this.props.labelId}
@@ -32,6 +33,7 @@ class RadioOptionsInput extends React.Component {
                      required={this.props.required
                                  ? 'required'
                                  : undefined}
+                     value={opt.value}
                      onChange={this.handleChange.bind(this, opt.value)}              
                      onFocus={this.props.onFocus.bind(this)}
                      onBlur={this.props.onBlur.bind(null, this.state.value)} />


### PR DESCRIPTION
**PR Notes**
Update to on change event for radio options. 

**Issue**
Radios are wrapped in a label so as the user clicks not on the radio the on change did not fire, an onClick has also been added to help with the click area